### PR TITLE
fix scheduled tutorial workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run build

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -5,50 +5,68 @@ on:
   schedule:
     - cron: '0 2 * * 0' # Run at 2AM UTC every Sunday
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Train Model
     steps:
       - name: Install Git LFS
-        run: sudo apt-get update && sudo apt-get install git-lfs && git lfs install
+        run: sudo apt-get update && sudo apt-get install -y git-lfs && git lfs install
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
-          token: ${{ secrets.PAT_TOKEN }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
+      - uses: oven-sh/setup-bun@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
-          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install && pnpm approve-builds && pnpm add faiss-node --allow-build=faiss-node && pnpm rebuild faiss-node
+        run: bun install
 
       - name: Train model from READMEs
-        run: node scripts/train_model.mjs
+        run: bun scripts/train_model.mjs
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
-      - name: Commit generated files
-        env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      - name: Check for changes
+        id: git-check
         run: |
-          git config --global user.name "Martin DONADIEU"
-          git config --global user.email "martindonadieu@gmail.com"
-          git lfs track "loadedVectorStore/*.json"
-          git lfs track "loadedVectorStore/*.index"
-          git add .gitattributes
-          git add loadedVectorStore/*.json loadedVectorStore/*.index
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit generated files
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git lfs track "loadedVectorStore/*.json" 2>/dev/null || true
+          git lfs track "loadedVectorStore/*.index" 2>/dev/null || true
+          git add .gitattributes 2>/dev/null || true
+          git add loadedVectorStore/*.json loadedVectorStore/*.index 2>/dev/null || true
           git add -A
-          git commit -m "Commit generated files"
-          git push origin main -f
+          git commit -m "chore: update trained model [skip ci]" \
+            -m "Automated update from train-model workflow" \
+            -m "Run ID: ${{ github.run_id }}"
+          git pull --rebase origin main || {
+            echo "Rebase conflict detected, aborting and retrying..."
+            git rebase --abort
+            git pull --no-rebase origin main
+            exit 1
+          }
+          git push origin main
         working-directory: ./
+
+      - name: Report no changes
+        if: steps.git-check.outputs.changes != 'true'
+        run: echo "No changes to commit - trained model is up to date"

--- a/.github/workflows/write-tutorials.yml
+++ b/.github/workflows/write-tutorials.yml
@@ -5,50 +5,68 @@ on:
   schedule:
     - cron: '0 3 * * 0' # Run at 3AM UTC every Sunday
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Write Tutorials
     steps:
       - name: Install Git LFS
-        run: sudo apt-get update && sudo apt-get install git-lfs && git lfs install
+        run: sudo apt-get update && sudo apt-get install -y git-lfs && git lfs install
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
-          token: ${{ secrets.PAT_TOKEN }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
+      - uses: oven-sh/setup-bun@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
-          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install && pnpm approve-builds && pnpm add faiss-node --allow-build=faiss-node && pnpm rebuild faiss-node
+        run: bun install
 
       - name: Generate tutorials
-        run: node scripts/generate_tutorials.mjs
+        run: bun scripts/generate_tutorials.mjs
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
-      - name: Commit generated files
-        env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      - name: Check for changes
+        id: git-check
         run: |
-          git config --global user.name "Martin DONADIEU"
-          git config --global user.email "martindonadieu@gmail.com"
-          git lfs track "loadedVectorStore/*.json"
-          git lfs track "loadedVectorStore/*.index"
-          git add .gitattributes
-          git add loadedVectorStore/*.json loadedVectorStore/*.index
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit generated files
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git lfs track "loadedVectorStore/*.json" 2>/dev/null || true
+          git lfs track "loadedVectorStore/*.index" 2>/dev/null || true
+          git add .gitattributes 2>/dev/null || true
+          git add loadedVectorStore/*.json loadedVectorStore/*.index 2>/dev/null || true
           git add -A
-          git commit -m "Commit generated files"
-          git push origin main -f
+          git commit -m "chore: update generated tutorials [skip ci]" \
+            -m "Automated update from write-tutorials workflow" \
+            -m "Run ID: ${{ github.run_id }}"
+          git pull --rebase origin main || {
+            echo "Rebase conflict detected, aborting and retrying..."
+            git rebase --abort
+            git pull --no-rebase origin main
+            exit 1
+          }
+          git push origin main
         working-directory: ./
+
+      - name: Report no changes
+        if: steps.git-check.outputs.changes != 'true'
+        run: echo "No changes to commit - generated tutorials are up to date"

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "proud-planet",
@@ -59,6 +59,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "faiss-node",
+  ],
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "tsx": "^4.19.4",
     "typescript": "^5.7.3",
     "zod": "^3.24.2"
-  }
+  },
+  "trustedDependencies": [
+    "faiss-node"
+  ]
 }


### PR DESCRIPTION
## Summary
- stop using PAT_TOKEN for checkout in scheduled tutorial workflows so checkout can use the default GitHub token
- align scheduled workflows with the repo's Bun setup and checkout@v6
- add Bun trusted dependency metadata so faiss-node builds during install
- avoid failing generated commits when there are no changes

## Failing runs checked
- Write Tutorials: https://github.com/Cap-go/tutorials/actions/runs/27488298879/job/81248562356
- Train Model: https://github.com/Cap-go/tutorials/actions/runs/27486751224

## Local verification
- bun install --frozen-lockfile
- bunx prettier --check package.json .github/workflows/deploy.yml .github/workflows/train-model.yml .github/workflows/write-tutorials.yml
- bun YAML parse for touched workflows
- bun native import smoke test for faiss-node and @langchain/community/vectorstores/faiss
- bun run build
