### PR TITLE
fix weekly website auto update workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Set branch name
         id: vars
         run: |
-          ref=${{ github.event.pull_request.head.ref }}
-          if [ "$ref" == "refs/heads/main" ]; then
+          ref="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          if [ "$ref" = "refs/heads/main" ] || [ "$ref" = "main" ]; then
             echo "branch=main" >> $GITHUB_OUTPUT
           else
             echo "branch=${ref}" >> $GITHUB_OUTPUT

--- a/.github/workflows/generate-actions-list.yml
+++ b/.github/workflows/generate-actions-list.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   generate-packages:
@@ -47,6 +48,8 @@ jobs:
           fi
       - name: Commit and push generated files
         if: steps.git-check.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -66,6 +69,7 @@ jobs:
             exit 1
           }
           git push origin main
+          gh workflow run deploy.yml --ref main
       - name: Report no changes
         if: steps.git-check.outputs.changes != 'true'
         run: echo "✅ No changes to commit - packages list is up to date"

--- a/.github/workflows/generate-actions-list.yml
+++ b/.github/workflows/generate-actions-list.yml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Run at midnight UTC every Sunday
 
 permissions:
   contents: write
@@ -34,7 +36,7 @@ jobs:
       - name: Generate packages list
         env:
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-        run: node scripts/generate_actions.mjs
+        run: bun scripts/generate_actions.mjs
       - name: Check for changes
         id: git-check
         run: |
@@ -53,7 +55,7 @@ jobs:
           git add .gitattributes 2>/dev/null || true
           git add loadedVectorStore/*.json loadedVectorStore/*.index 2>/dev/null || true
           git add -A
-          git commit -m "chore: update NPM packages list [skip ci]" \
+          git commit -m "chore: update NPM packages list" \
             -m "Automated update from generate-actions workflow" \
             -m "Run ID: ${{ github.run_id }}"
           # Try to pull and rebase in case of conflicts

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   deploy:
@@ -47,6 +48,8 @@ jobs:
 
       - name: Commit generated files
         if: steps.git-check.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -65,6 +68,7 @@ jobs:
             exit 1
           }
           git push origin main
+          gh workflow run deploy.yml --ref main
         working-directory: ./
 
       - name: Report no changes

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -55,7 +55,7 @@ jobs:
           git add .gitattributes 2>/dev/null || true
           git add loadedVectorStore/*.json loadedVectorStore/*.index 2>/dev/null || true
           git add -A
-          git commit -m "chore: update trained model [skip ci]" \
+          git commit -m "chore: update trained model" \
             -m "Automated update from train-model workflow" \
             -m "Run ID: ${{ github.run_id }}"
           git pull --rebase origin main || {

--- a/.github/workflows/write-readmes.yml
+++ b/.github/workflows/write-readmes.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   fetch-and-create:
@@ -47,6 +48,8 @@ jobs:
           fi
       - name: Commit and push generated files
         if: steps.git-check.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -70,6 +73,7 @@ jobs:
           }
           
           git push origin main
+          gh workflow run deploy.yml --ref main
 
       - name: Report no changes
         if: steps.git-check.outputs.changes != 'true'

--- a/.github/workflows/write-readmes.yml
+++ b/.github/workflows/write-readmes.yml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * 0' # Run at 1AM UTC every Sunday
 
 permissions:
   contents: write
@@ -32,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Create READMEs
-        run: node scripts/write_readme.mjs
+        run: bun scripts/write_readme.mjs
         env:
           BEARER_TOKEN: ${{ secrets.BEARER_TOKEN }}
       - name: Check for changes
@@ -55,7 +57,7 @@ jobs:
           git add loadedVectorStore/*.json loadedVectorStore/*.index 2>/dev/null || true
           git add -A
           
-          git commit -m "chore: update READMEs from NPM packages [skip ci]" \
+          git commit -m "chore: update READMEs from NPM packages" \
             -m "Automated update from write-readmes workflow" \
             -m "Run ID: ${{ github.run_id }}"
           

--- a/.github/workflows/write-tutorials.yml
+++ b/.github/workflows/write-tutorials.yml
@@ -55,7 +55,7 @@ jobs:
           git add .gitattributes 2>/dev/null || true
           git add loadedVectorStore/*.json loadedVectorStore/*.index 2>/dev/null || true
           git add -A
-          git commit -m "chore: update generated tutorials [skip ci]" \
+          git commit -m "chore: update generated tutorials" \
             -m "Automated update from write-tutorials workflow" \
             -m "Run ID: ${{ github.run_id }}"
           git pull --rebase origin main || {

--- a/.github/workflows/write-tutorials.yml
+++ b/.github/workflows/write-tutorials.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   deploy:
@@ -47,6 +48,8 @@ jobs:
 
       - name: Commit generated files
         if: steps.git-check.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -65,6 +68,7 @@ jobs:
             exit 1
           }
           git push origin main
+          gh workflow run deploy.yml --ref main
         working-directory: ./
 
       - name: Report no changes


### PR DESCRIPTION
## Summary
- schedule package list generation every Sunday at 00:00 UTC
- schedule README fetching every Sunday at 01:00 UTC
- keep model training at 02:00 UTC and tutorial generation at 03:00 UTC
- remove [skip ci] from generated commits so weekly updates trigger the website deploy workflow
- use Bun to run the generator scripts in workflows

## Weekly chain
1. Generate Packages List from NPM: Sunday 00:00 UTC
2. Fetch and Create READMEs: Sunday 01:00 UTC
3. Train Model: Sunday 02:00 UTC
4. Write Tutorials: Sunday 03:00 UTC
5. Deploy runs from generated pushes to main

## Local verification
- bunx prettier --check .github/workflows/generate-actions-list.yml .github/workflows/write-readmes.yml .github/workflows/train-model.yml .github/workflows/write-tutorials.yml
- bun YAML parse for touched workflows
- git diff --check
